### PR TITLE
Fix missing DOMContentLoaded handler closure

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -597,9 +597,4 @@ style.innerHTML = `
 `;
 document.head.appendChild(style);
 
-
-
-
-
-
-
+});


### PR DESCRIPTION
## Summary
- close DOMContentLoaded handler in `scripts.js`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8a839b58833182d89b92d94ad7ed