### PR TITLE
Load Gemini API key from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your API key
+GOOGLE_API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Joseph Rodriguez BI Chatbot
+
+This Flask application uses Google's generative AI (Gemini) to provide responses based on information stored in `knowledgebase/knowledge.json`.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the required environment variable before starting the app:
+
+```bash
+export GOOGLE_API_KEY=your_api_key_here
+```
+
+The application will fail to start if `GOOGLE_API_KEY` is not set.
+
+3. Run the server:
+
+```bash
+python app.py
+```
+
+## Environment
+
+You can also create a `.env` file and load it using a tool like `dotenv`. An example file is provided below.
+
+
+### Sample .env
+
+# Copy this file to .env and fill in your API key
+GOOGLE_API_KEY=your_api_key_here
+

--- a/app.py
+++ b/app.py
@@ -6,8 +6,12 @@ import json
 
 app = Flask(__name__)
 
-# Initialize the GenAI client (API key should be kept secret)
-client = genai.Client(api_key="AIzaSyCmVExBw1v18vCNcdYzIwTrX00O5_9J3SE")
+# Initialize the GenAI client using an environment variable
+api_key = os.environ.get('GOOGLE_API_KEY')
+if not api_key:
+    raise EnvironmentError('GOOGLE_API_KEY environment variable not set')
+
+client = genai.Client(api_key=api_key)
 
 # Load the entire knowledge.json from the "knowledgebase" folder
 knowledge_path = os.path.join('knowledgebase', 'knowledge.json')


### PR DESCRIPTION
## Summary
- load Gemini API key from `GOOGLE_API_KEY` env variable
- add README with setup instructions
- provide `.env.example` showing required variable

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8bd7c6e88331a168218fb468061c